### PR TITLE
集計結果編集機能の実装

### DIFF
--- a/django/qumitoru/questionnaire/tests/test_score_list.py
+++ b/django/qumitoru/questionnaire/tests/test_score_list.py
@@ -8,6 +8,7 @@ from questionnaire.models import QuestionareScore
 from questionnaire.tests.factories import MakeQuestionDataFactory
 
 import datetime
+import json
 
 class QuestionareScoreListTests(APITestCase):
 
@@ -26,3 +27,13 @@ class QuestionareScoreListTests(APITestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data['count'], 1)
         self.assertEqual(resp.data['results'][0]['id'], scoredata.id)
+
+    def test_update_score_data(self):
+        q = MakeQuestionDataFactory.makeData(self)
+        scoredata = QuestionareScore.objects.create(q1=10,q2=10,q3=5,q4=4,q5=4,q6=4,q7=4,day_of_week=1,is_finished=True,take_at=datetime.date.today(),user_id=q.user.id,questionare_id=q.id)
+        url = reverse('questionnaire:questionarescore-score-update', kwargs=dict(pk=u'1'))
+        resp = self.client.post(url, {'scoreList': ['1,1,1,1,1,1,1'], 'target_id': [str(scoredata.id)]})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(QuestionareScore.objects.filter(pk=scoredata.id).first().q1, 1)
+        self.assertEqual(json.loads(resp.content)['result'], 'SUCCESS')
+

--- a/django/qumitoru/questionnaire/views.py
+++ b/django/qumitoru/questionnaire/views.py
@@ -1,8 +1,10 @@
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
 from .models import QuestionareScore
 from .serializers import QuestionareScoreSerializer
 from .paginations import CustomPagination
+from django.http import JsonResponse
 
 import datetime
 
@@ -19,6 +21,21 @@ class QuestionareScoreViewSet(ModelViewSet):
         period = self.makePeriodList(self.request)
         return QuestionareScore.objects.filter(user_id=user_id, take_at__range=period, is_finished=True).order_by('-take_at').reverse()
 
+    @action(detail=True, methods=['post'])
+    def score_update(self, request, *args, **kwargs):
+        score_list = self.convertInt(request.POST.get('scoreList').split(','))
+        target_id = request.POST.get('target_id')
+        QuestionareScore.objects.filter(pk=int(target_id)).update(
+            q1=score_list[0],
+            q2=score_list[1],
+            q3=score_list[2],
+            q4=score_list[3],
+            q5=score_list[4],
+            q6=score_list[5],
+            q7=score_list[6]
+        )
+        return JsonResponse({'result': 'SUCCESS'})
+
     """
     modules
     """
@@ -34,4 +51,6 @@ class QuestionareScoreViewSet(ModelViewSet):
         period = [periodStart, periodEnd]
         return period
 
-
+    def convertInt(self, list):
+        convertesList = [int(i) if i.isdigit() else None for i in list]
+        return convertesList

--- a/docker/jsonserver/server/server.js
+++ b/docker/jsonserver/server/server.js
@@ -56,6 +56,9 @@ server.get("/questionnare1", (req, resp) => {
 server.get("/questionnare2", (req, resp) => {
   resp.status(200).json(db.questionnare[1]);
 });
+server.post("/score_update", (req, resp) => {
+  resp.status(200).json({ result: "SUCCESS" });
+});
 
 server.use(router);
 server.listen(33000, () => {

--- a/vue/app/src/assets/css/scoreEditModal.scss
+++ b/vue/app/src/assets/css/scoreEditModal.scss
@@ -1,0 +1,91 @@
+.score-data-list {
+  width: 80% !important;
+  max-width: 900px !important;
+  margin: 0 auto !important;
+  margin-top: 30px !important;
+}
+.vm--modal {
+  top: 5% !important;
+  height: 86% !important;
+  width: 80% !important;
+  max-width: 600px !important;
+  padding-top: 2% !important;
+  color: darkgreen !important;
+  img {
+    width: 65%;
+    max-width: 300px;
+  }
+  .img-frame {
+    &__title {
+      padding-left: 5%;
+      font-weight: bold;
+    }
+    &__chip {
+      height: 100% !important;
+      margin: 0 auto !important;
+      display: block !important;
+      width: 70% !important;
+      margin-top: 3% !important;
+      .v-chip__content {
+        display: block !important;
+        margin: 0 auto !important;
+        padding: 1% !important;
+        text-align: center !important;
+      }
+    }
+  }
+  .ocr-result-frame {
+    margin-top: 5%;
+    &__title {
+      font-weight: bold;
+      padding-left: 5%;
+    }
+    &__list {
+      padding-top: 3%;
+      display: flex;
+      justify-content: center;
+    }
+  }
+  .score-frame {
+    border: 1px solid coral;
+    border-radius: 5px;
+    display: flex;
+    margin-right: 1%;
+    text-align: center;
+    .score-label {
+      display: block;
+      background: coral;
+      color: white;
+      width: 35px;
+      border-top-left-radius: 4px;
+      border-bottom-left-radius: 5px;
+    }
+    .score-val {
+      display: block;
+      width: 35px;
+    }
+  }
+  .edit-btn-frame {
+    margin-top: 3%;
+    text-align: right;
+    padding-right: 3%;
+    .v-btn {
+      margin-left: 3% !important;
+    }
+  }
+  .edit-select-frame {
+    .v-text-field {
+      margin: 3% !important;
+    }
+    .row {
+      justify-content: center !important;
+    }
+  }
+  .loading-frame {
+    margin-top: 100px !important;
+  }
+  .loading {
+    width: 30px !important;
+    height: 30px !important;
+  }
+}

--- a/vue/app/src/components/scoreEditModal.vue
+++ b/vue/app/src/components/scoreEditModal.vue
@@ -1,0 +1,206 @@
+<template>
+  <modal name="detail-modal">
+    <div class="img-frame">
+      <div class="img-frame__title"><v-icon>mdi-clipboard-outline</v-icon> 読み込んだアンケート</div>
+      <v-divider></v-divider>
+      <v-chip class="img-frame__chip">
+        <img :src="getImgFromS3(this.detailImg)">
+      </v-chip>
+    </div>
+    <div class="ocr-result-frame">
+      <div class="ocr-result-frame__title"><v-icon>mdi-magnify-scan</v-icon> 認識結果</div>
+      <v-divider></v-divider>
+      <div v-if="!isEditting">
+        <div v-if="!isEditting" class="ocr-result-frame__list">
+          <div
+            class="score-frame"
+            v-for="(score, index) in this.scoreList"
+            :key="index"
+          >
+            <span class="score-label">Q{{index + 1}}:</span>
+            <span class="score-val">{{score}}</span>
+          </div>
+        </div>
+        <div class="edit-btn-frame">
+          <v-btn @click="openScoreEditFrame" class="editStartBtn">修正する</v-btn>
+        </div>
+      </div>
+      <div v-else>
+        <div class="edit-select-frame">
+          <v-row align="center">
+            <v-col
+              class="d-flex"
+            >
+              <v-select :items="tenScales" label="Q1" v-model="scoreList[0]"></v-select>
+              <v-select :items="tenScales" label="Q2" v-model="scoreList[1]"></v-select>
+              <v-select :items="fiveScales" label="Q3" v-model="scoreList[2]"></v-select>
+              <v-select :items="fiveScales" label="Q4" v-model="scoreList[3]"></v-select>
+              <v-select :items="fiveScales" label="Q5" v-model="scoreList[4]"></v-select>
+              <v-select :items="fiveScales" label="Q6" v-model="scoreList[5]"></v-select>
+              <v-select :items="fiveScales" label="Q7" v-model="scoreList[6]"></v-select>
+            </v-col>
+          </v-row>
+        </div>
+        <div class="edit-btn-frame" v-if="!isLoading">
+          <span v-if="isEdited" class="updateResult">{{this.updateResult}}</span>
+          <v-btn @click="submit" class="submitBtn">登録する</v-btn>
+          <v-btn @click="closeScoreEditFrame">キャンセル</v-btn>
+        </div>
+        <div v-else>
+          <vue-loading type="spin" color="coral" class="loading"></vue-loading>
+        </div>
+      </div>
+    </div>
+  </modal>
+</template>
+
+<script>
+import axios from 'axios'
+import { VueLoading } from 'vue-loading-template'
+
+export default {
+  data () {
+    return {
+      dataList: null,
+      detailImg: null,
+      scoreList: null,
+      isEditting: false,
+      isLoading: false,
+      isEdited: false,
+      targetId: null,
+      updateResult: null,
+      tenScales: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, ''],
+      fiveScales: [5, 4, 3, 2, 1, ''],
+      dates: [],
+      headers: [
+        {
+          text: "実施日",
+          align: 'start',
+          value: 'date',
+        },
+        { text: 'Q1', value: 'q1' },
+        { text: 'Q2', value: 'q2' },
+        { text: 'Q3', value: 'q3' },
+        { text: 'Q4', value: 'q4' },
+        { text: 'Q5', value: 'q5' },
+        { text: 'Q6', value: 'q6' },
+        { text: 'Q7', value: 'q7' },
+        { text: '撮影画像', value: 'img' },
+        { text: '処理時刻', value: 'take_at' }
+      ],
+      scoreDataList: [
+      ],
+      convertDateToString: function(dateString) {
+        var date = new Date(dateString);
+        return date.toLocaleString();
+      },
+      getQuestionnareUpdateApiUrl: function() {
+        let url;
+        if(process.env.NODE_ENV === 'development'){
+          url = 'http://0.0.0.0:8001/questionnaire/questionnaire/'+ this.$session.get("userid") +'/score_update/'
+        }else if(window.location.port === '8081'){ // testing
+          url = 'http://172.17.0.1:33000/score_update'
+        }else if(process.env.NODE_ENV === 'production'){
+          url = 'http://0.0.0.0:1337/questionnaire/questionnaire/'+ this.$session.get("userid") +'/score_update/'
+        }
+        return url;
+      }
+    }
+  },
+  components: {
+    VueLoading,
+  },
+  methods: {
+    openModal(img, dataList) {
+      this.detailImg = img
+      this.dataList = dataList
+      this.$modal.show('detail-modal');
+      this.isEditting = false;
+      this.updateResult = null;
+      this.currentScoreData();
+    },
+    openScoreEditFrame() {
+      this.currentScoreData();
+      this.isEditting = true;
+    },
+    closeScoreEditFrame() {
+      this.currentScoreData();
+      this.isEditting = false;
+      this.updateResult = null;
+    },
+    currentScoreData() {
+      for(let data of this.dataList){
+        if(data.file_path == this.detailImg){
+          this.targetId = data.id;
+          this.scoreList = [
+            data.q1,
+            data.q2,
+            data.q3,
+            data.q4,
+            data.q5,
+            data.q6,
+            data.q7
+            ]
+        }
+      }
+    },
+    updateEditScoreData(id, scoreList, dataList) {
+      for(let data of dataList){
+        if(data.id == id){
+          data.q1 = scoreList[0],
+          data.q2 = scoreList[1],
+          data.q3 = scoreList[2],
+          data.q4 = scoreList[3],
+          data.q5 = scoreList[4],
+          data.q6 = scoreList[5],
+          data.q7 = scoreList[6]
+        }
+      }
+    },
+    getImgFromS3(img_path) {
+      if(process.env.NODE_ENV === 'development'){
+        return "https://qumitoru-dev.s3-ap-northeast-1.amazonaws.com/" + img_path
+      }else{
+        return "https://qumitoru-prd.s3-ap-northeast-1.amazonaws.com/" + img_path
+      }
+    },
+    submit() {
+      this.isLoading = true;
+      let formData = new FormData();
+      formData.append('scoreList', this.scoreList);
+      formData.append('target_id', this.targetId);
+      let config = {
+        headers: {
+          'content-type': 'multipart/form-data',
+          'Access-Control-Allow-Origin': 'http://localhost:8080'
+        }
+      };
+      let url = this.getQuestionnareUpdateApiUrl();
+      axios.post(url, formData, config)
+      .then(function(response){
+          this.isEdited = true;
+          this.isLoading = false;
+          if(response.data.result == 'SUCCESS'){
+            this.updateEditScoreData(this.targetId, this.scoreList, this.dataList);
+            // this.updateEditScoreData(this.targetId, this.scoreList, this.scoreDataList)
+            this.$emit('updateScoreDataList', this.targetId, this.scoreList);
+            this.updateResult = '更新が完了しました。'
+          }else{
+            this.updateResult = '通信エラーにより更新できませんでした。'
+          }
+          this.isLoading = false;
+      }.bind(this))
+      .catch(e => {
+        this.isEdited = false;
+        this.updateResult = '通信エラーにより更新できませんでした。'
+        this.isLoading = false;
+        console.log(e);
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+  @import "../assets/css/scoreEditModal.scss";
+</style>

--- a/vue/app/src/views/List.vue
+++ b/vue/app/src/views/List.vue
@@ -30,6 +30,11 @@
         @input="getList"
         class="scoreDataPageNation"
       ></v-pagination>
+      <ScoreEditModal
+        ref="scoreEditModal"
+        @updateScoreDataList='updateScoreDataList'
+      >
+      </ScoreEditModal>
     </div>
   </div>
 </template>
@@ -39,6 +44,7 @@ import axios from 'axios'
 import { VueLoading } from 'vue-loading-template'
 import Questionnaire from '../components/questionnaire.vue'
 import AggregationPeriod from '../components/aggregationPeriod.vue'
+import ScoreEditModal from '../components/scoreEditModal.vue'
 
 export default {
   name: 'List',
@@ -96,9 +102,13 @@ export default {
   components: {
     VueLoading,
     Questionnaire,
-    AggregationPeriod
+    AggregationPeriod,
+    ScoreEditModal
   },
   methods: {
+    openModal(img) {
+      this.$refs.scoreEditModal.openModal(img, this.dataList)
+    },
     getImgFromS3(img_path) {
       if(process.env.NODE_ENV === 'development'){
         return "https://qumitoru-dev.s3-ap-northeast-1.amazonaws.com/" + img_path
@@ -193,6 +203,19 @@ export default {
       let defaultDateRangeMin = dt.toISOString().substr(0, 10);
       let defaultDateRangeMax = new Date().toISOString().substr(0, 10);
       this.dates = [defaultDateRangeMin, defaultDateRangeMax];
+    },
+    updateScoreDataList(id, scoreList) {
+      for(let data of this.scoreDataList){
+        if(data.id == id){
+          data.q1 = scoreList[0],
+          data.q2 = scoreList[1],
+          data.q3 = scoreList[2],
+          data.q4 = scoreList[3],
+          data.q5 = scoreList[4],
+          data.q6 = scoreList[5],
+          data.q7 = scoreList[6]
+        }
+      }
     }
   }
 }

--- a/vue/app/tests/e2e/specs/list.js
+++ b/vue/app/tests/e2e/specs/list.js
@@ -11,15 +11,12 @@ module.exports = {
       // 1秒待つ
       .pause(3000)
       // アップロード画面へ移動
-      .saveScreenshot('./screenshots/screenshot_list1.png')
       .click('a[href="/list"]')
       // 1秒待つ
       .pause(1000)
       .useXpath()
-      .saveScreenshot('./screenshots/screenshot_list.png')
       .assert.elementCount('.v-data-table__wrapper table tbody tr', 10)
       .click('//button[contains(@aria-label, "Next page")]')
-      .saveScreenshot('./screenshots/screenshot_list.png')
       .assert.elementCount('.v-data-table__wrapper table tbody tr', 1)
       .end();
   },
@@ -34,12 +31,10 @@ module.exports = {
       // 1秒待つ
       .pause(3000)
       // 集計一覧画面へ移動
-      .saveScreenshot('./screenshots/screenshot_list1.png')
       .click('a[href="/list"]')
       // 1秒待つ
       .pause(1000)
       .useXpath()
-      // .saveScreenshot('./screenshots/screenshot_list.png')
       .assert.elementCount('.v-data-table__wrapper table tbody tr', 10)
       .click('//div[contains(@class, "date-picker-field")]')
       .pause(1000)
@@ -48,6 +43,31 @@ module.exports = {
       .click('//div[contains(@class, "v-date-picker-table--date")]/table/tbody/tr[2]/td[1]/button')
       .pause(5000)
       .assert.elementCount('.v-data-table__wrapper table tbody tr', 2)
+      .end();
+  },
+  'アンケートを編集する': (browser) => {
+    browser
+      .url(browser.launch_url)
+      .useCss()
+      // ログイン
+      .setValue('input[type=text]', 'validuser')
+      .setValue('input[type=password]', 'validpassword')
+      .click('button[type="button"]')
+      // 1秒待つ
+      .pause(1000)
+      // 集計結果一覧画面へ移動
+      .click('a[href="/list"]')
+      .waitForElementVisible('.score-data-list', 1000)
+      // 1秒待つ
+      .pause(1000)
+      .click('.editBtn')
+      .assert.containsText('.img-frame__title', '読み込んだアンケート')
+      .click('.editStartBtn')
+      .click('.v-select__slot')
+      .useXpath()
+      .click('//div[contains(@role, "listbox")]/div[6]')
+      .click('//button[contains(@class, "submitBtn")]')
+      .assert.containsText('//span[contains(@class, "updateResult")]', '更新が完了しました。')
       .end();
   }
 };


### PR DESCRIPTION
# issue
#17

# 内容
##### 2.集計結果の編集機能
  - 上記集計一覧画面のアンケート画像をクリックすることで編集画面(モーダル)表示
  - 編集画面は、アンケート画像・集計結果・修正ボタンから構成される
    - 修正ボタンをクリックすることで、集計結果がSelect方式の入力画面に切り替わり、下部に更新ボタンが表示される
    - 更新ボタンをクリックすることで、入力された項目で集計結果が更新される。
      - バックエンドにリクエストを送り、DBの値を更新する
      - 更新結果に応じてアラート表示を行う
      

# 動作確認

#### 2.集計結果の編集機能
1. 集計結果一覧の中から適当なアンケートデータのアンケート画像をクリックする
2. モーダルが出現し、アンケート画像・集計結果・修正ボタンが表示されていることを確認する
3. 修正ボタンをクリックする
4. 集計結果がSelect方式の入力項目に切り替わること&更新ボタンが出現することを確認する
5. 適当に結果数値を変更する
6. 更新ボタンをクリックする
7. 更新しましたというアラートが表示されることを確認する
8. ページを再読み込みしても、修正した内容が集計一覧にも反映されていることを確認する

# 影響範囲
#### フロントエンド
- 集計結果一覧画面
  - 「集計結果編集画面(モーダル)」を追加

#### バックエンド
- QuestionnareScoreモデル
  - 編集処理によるDB内の既存データ更新処理