### PR TITLE
サイドメニューのレスポンシブ対応

### DIFF
--- a/vue/app/src/components/sidebar.vue
+++ b/vue/app/src/components/sidebar.vue
@@ -28,7 +28,7 @@
       dense
     >
       <v-list-item
-        v-for="list in nav_list.lists"
+        v-for="list in navListFilter"
         :key="list.name"
         :to="list.link"
       >
@@ -56,6 +56,8 @@ export default {
   data() {
     return {
       username: this.$session.get('username'),
+      isSmartPhoneWindowSize: false,
+      spNavMenus: ['/dashboard','/upload','/howto'],
       nav_list:
         {
           lists: [
@@ -93,7 +95,27 @@ export default {
       this.$session.destroy();
       this.$emit('logouted', true);
       router.push("/auth");
+    },
+    checkWindowSize() {
+      this.isSmartPhoneWindowSize = window.innerWidth < 767 ? true: false;
     }
+  },
+  computed: {
+    navListFilter:function() {
+      let filteredList = [];
+      let lists = this.nav_list.lists;
+      for(let i in lists){
+        if(this.isSmartPhoneWindowSize && this.spNavMenus.includes(lists[i].link)){
+          filteredList.push(lists[i]);
+        }else if(!this.isSmartPhoneWindowSize){
+          filteredList.push(lists[i]);
+        }
+      }
+      return filteredList;
+    }
+  },
+  mounted() {
+    this.checkWindowSize();
   }
 }
 </script>

--- a/vue/app/src/views/Download.vue
+++ b/vue/app/src/views/Download.vue
@@ -17,17 +17,22 @@
 </script>
 <style lang="scss">
   .downloadFrame {
-    width: 70%;
+    width: 80%;
     margin: 0 auto;
     margin-top: 20%;
     text-align: center !important;
     .v-card__title {
       display: block;
     }
+    .downloadBtn {
+      background: coral !important;
+      color: white !important;
+      font-weight: bold;
+    }
   }
-  .downloadBtn {
-    background: coral !important;
-    color: white !important;
-    font-weight: bold;
+  @media (max-width: 767px) {
+    .downloadFrame {
+      display: none !important;
+    }
   }
 </style>

--- a/vue/app/tests/e2e/specs/list.js
+++ b/vue/app/tests/e2e/specs/list.js
@@ -69,6 +69,24 @@ module.exports = {
       .click('//button[contains(@class, "submitBtn")]')
       .assert.containsText('//span[contains(@class, "updateResult")]', '更新が完了しました。')
       .end();
+  },
+  'スマホでは非表示': (browser) => {
+    browser
+      .resizeWindow(600, 700)
+      .url(browser.launch_url)
+      // ログイン
+      .useCss()
+      .setValue('input[type=text]', 'validuser')
+      .setValue('input[type=password]', 'validpassword')
+      .click('button[type="button"]')
+      // 1秒待つ
+      .pause(3000)
+      // アップロード画面へ移動
+      .url(browser.launch_url+'/list')
+      // 1秒待つ
+      .pause(1000)
+      .assert.not.visible('.scoreDataListFrame')
+      .end();
   }
 };
 

--- a/vue/app/tests/e2e/specs/sidebar.js
+++ b/vue/app/tests/e2e/specs/sidebar.js
@@ -1,0 +1,22 @@
+module.exports = {
+  beforeEach: (browser) => browser.init(),
+  'スマホでは「集計一覧」「ダウンロード」は非表示': (browser) => {
+    browser
+      .resizeWindow(600, 700)
+      .url(browser.launch_url)
+      // ログイン
+      .useCss()
+      .setValue('input[type=text]', 'validuser')
+      .setValue('input[type=password]', 'validpassword')
+      .click('button[type="button"]')
+      // 3秒待つ
+      .pause(3000)
+      // アップロード画面へ移動
+      .url(browser.launch_url+'/list')
+      // 1秒待つ
+      .pause(1000)
+      .assert.not.containsText('.sidemenu', '集計一覧')
+      .assert.not.containsText('.sidemenu', 'ダウンロード')
+      .end();
+  }
+};


### PR DESCRIPTION
# issue
#5 

# 内容
### サイドメニューのレスポンシブ対応
  - スマホ表示(767px未満)の場合は下記のメニューボタンは非表示とする
    - ダウンロード
    - 集計一覧
  - スマホ表示(767px未満)の場合は下記のコンポーネントは非表示とする
    - ダウンロード
    - 集計一覧 


# 動作確認
1. スマホ表示(767px未満)の際に以下の挙動を確認する
    - サイドメニューの"ダウンロード"ボタンが非表示
    - サイドメニューの"集計一覧"が非表示
2. スマホ表示(767px未満)の状態で以下のURLにアクセスし何も表示されないことを確認する
    - "/download"
    - "/list"


# 影響範囲
- フロントエンド
  - サイドメニュー
  - ダウンロード画面
  - 集計一覧画面 
