### PR TITLE
Provisioned Concurrencyの設定

### DIFF
--- a/docker/terraform/src/stg/modules/lambda/aws_lambda_function.tf
+++ b/docker/terraform/src/stg/modules/lambda/aws_lambda_function.tf
@@ -1,3 +1,5 @@
+# lambda(scanner)_______________________________________________
+
 resource "aws_lambda_function" "lambda_scanner_container" {
   function_name = "lambda_scanner_container_${var.env}"
   role          = var.lambda_container_role_arn
@@ -5,7 +7,7 @@ resource "aws_lambda_function" "lambda_scanner_container" {
   image_uri     = "${var.lambda-scanner-image-url}:latest"
   memory_size   = 3008
 	timeout       = 120
-
+  publish = true
   lifecycle {
     ignore_changes = [image_uri]
   }
@@ -17,6 +19,21 @@ resource "aws_lambda_function" "lambda_scanner_container" {
     }
   }
 }
+
+resource "aws_lambda_alias" "lambda_scanner" {
+  name             = "scanner_alias_${var.env}"
+  description      = "lambda scanner alias"
+  function_name    = aws_lambda_function.lambda_scanner_container.function_name
+  function_version = aws_lambda_function.lambda_scanner_container.version
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "lambda_scanner_container" {
+  function_name                     = aws_lambda_alias.lambda_scanner.function_name
+  provisioned_concurrent_executions = 2
+  qualifier                         = aws_lambda_alias.lambda_scanner.name
+}
+
+# lambda(cutout&predict)_______________________________________________
 
 resource "aws_lambda_function" "lambda_predict_container" {
 	function_name = "lambda_predict_container_${var.env}"


### PR DESCRIPTION
# issue
#35 

# 内容
- Lambdaのcold start の対策のために以下の対応を行う
  - 画像アップロード時のscanner API(lambda)にProvisioned Concurrencyの設定を追加
    - 今回の対応では常時２台稼働に設定
    - Provisioned Concurrencyを設定するためにエイリアスを作成
  - なおProvisioned Concurrencyの設定はterraformを経由して行う


# 動作確認
1. AWSコンソール画面においてProvisioned Concurrencyに以下の値が設定されていることを確認する
    - 「プロビジョニングされた同時実行」：２


# 影響範囲
- Lambda (scanner lambda)