### PR TITLE
 [Bug]本番環境でDRFのデバック画面が表示されてしまう不具合への対応

### DIFF
--- a/django/qumitoru/qumitoru/settings/base.py
+++ b/django/qumitoru/qumitoru/settings/base.py
@@ -132,6 +132,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication'
     ],
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 3
 }

--- a/django/qumitoru/qumitoru/settings/prd.py
+++ b/django/qumitoru/qumitoru/settings/prd.py
@@ -2,7 +2,7 @@ from .base import *
 import os
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [os.environ['ALLOWED_HOST'], '127.0.0.1', 'qumitoru.net']
 


### PR DESCRIPTION
# issue
#40

# 内容
- 本番環境でDRFのデバック画面が表示されてしまう不具合が確認されたため、その対応を行う
[対応方針]
  - Djangoの本番環境設定ファイルのREST_FRAMEWORKの部分にDEFAULT_RENDERER_CLASSES を追加


# 動作確認
1. qumitoru.net/questionnaire/ にアクセスする
2. デバック画面が表示されないことを確認する

# 影響範囲
